### PR TITLE
Changed PixelPalette path name casing to reflect project directory name

### DIFF
--- a/app/require-config.js
+++ b/app/require-config.js
@@ -8,7 +8,7 @@ require.config({
         "intersection": "lib/intersection/intersection",
         "keycodes": "lib/key-codes/dist/key-codes",
         "lzma": "lib/lzma/src/lzma",
-        "PixelPalette": "lib/PixelPalette/dist/PixelPalette",
+        "PixelPalette": "lib/pixelpalette/dist/PixelPalette",
         "Recorderjs": "lib/RecorderJS",
         "text": "lib/text/text",
         "Tone": "lib/tone/Tone",


### PR DESCRIPTION
The PixelPalette path name in require-config.js was causing a 404 Resource Not Found error when building the app (which causes an indefinite loading screen) due to the stated path having capitalized PixelPalette. This changes the path to lower-case to properly reflect the actual project directory name, fixing the 404 Error.